### PR TITLE
feat: add MCP endpoint with JSON-RPC 2.0

### DIFF
--- a/src/mcp/index.js
+++ b/src/mcp/index.js
@@ -1,0 +1,207 @@
+const crypto = require('crypto');
+const db = require('../db');
+
+const TOOLS = [
+  {
+    name: 'listar_facturas',
+    description: 'Lista facturas con filtros opcionales (estado, proveedor, rango de fechas).',
+    inputSchema: {
+      type: 'object', properties: {
+        estado: { type: 'string', enum: ['recibida', 'revision', 'aprobada', 'rechazada', 'causada', 'pagada'] },
+        proveedor: { type: 'string' },
+        fechaInicio: { type: 'string' },
+        fechaFin: { type: 'string' },
+        limite: { type: 'number', default: 50 }
+      }
+    }
+  },
+  {
+    name: 'resumen_dashboard',
+    description: 'Obtiene el resumen del dashboard: totales por estado, valor del mes.',
+    inputSchema: { type: 'object', properties: {} }
+  },
+  {
+    name: 'listar_proveedores',
+    description: 'Lista todos los proveedores registrados.',
+    inputSchema: { type: 'object', properties: { limite: { type: 'number', default: 50 } } }
+  },
+  {
+    name: 'facturas_por_vencer',
+    description: 'Facturas próximas a vencer (límite de pago en los próximos 7 días).',
+    inputSchema: { type: 'object', properties: { dias: { type: 'number', default: 7 } } }
+  },
+  {
+    name: 'buscar_factura',
+    description: 'Busca una factura por número.',
+    inputSchema: { type: 'object', properties: { numero: { type: 'string' } }, required: ['numero'] }
+  },
+  {
+    name: 'listar_categorias',
+    description: 'Lista las categorías de compra activas.',
+    inputSchema: { type: 'object', properties: {} }
+  },
+  {
+    name: 'listar_areas',
+    description: 'Lista las áreas de la organización.',
+    inputSchema: { type: 'object', properties: {} }
+  },
+  {
+    name: 'estadisticas',
+    description: 'Estadísticas generales del sistema documental.',
+    inputSchema: { type: 'object', properties: {} }
+  }
+];
+
+async function ejecutarTool(name, args) {
+  switch (name) {
+    case 'listar_facturas': {
+      const c = [], p = [];
+      if (args.estado) { c.push('f.estado = $' + (p.length + 1)); p.push(args.estado); }
+      if (args.proveedor) { c.push('(p.nombre ILIKE $' + (p.length + 1) + ' OR p.nit ILIKE $' + (p.length + 1) + ')'); p.push('%' + args.proveedor + '%'); }
+      if (args.fechaInicio) { c.push('f.recibida_en >= $' + (p.length + 1)); p.push(args.fechaInicio); }
+      if (args.fechaFin) { c.push('f.recibida_en <= $' + (p.length + 1)); p.push(args.fechaFin); }
+      const w = c.length ? 'WHERE ' + c.join(' AND ') : '';
+      const lim = Math.min(parseInt(args.limite) || 50, 200);
+      const r = await db.query(
+        `SELECT f.id, f.numero_factura, f.valor_total, f.estado, f.recibida_en, f.limite_pago,
+                p.nombre AS proveedor, c.nombre AS categoria
+         FROM facturas f
+         LEFT JOIN proveedores p ON p.id = f.proveedor_id
+         LEFT JOIN categorias_compra c ON c.id = f.categoria_id
+         ${w}
+         ORDER BY f.recibida_en DESC
+         LIMIT ${lim}`, p);
+      return r.rows;
+    }
+    case 'resumen_dashboard': {
+      const r = await db.query(`
+        SELECT estado, COUNT(*)::int AS total FROM facturas GROUP BY estado
+      `);
+      const v = await db.query(`
+        SELECT COALESCE(SUM(valor_total), 0)::numeric AS valor
+        FROM facturas WHERE estado IN ('causada','pagada')
+        AND DATE_TRUNC('month', creado_en) = DATE_TRUNC('month', NOW())
+      `);
+      const resumen = { total: 0, valor_mes: parseFloat(v.rows[0]?.valor || 0) };
+      for (const row of r.rows) { resumen.total += row.total; resumen[row.estado] = row.total; }
+      return resumen;
+    }
+    case 'listar_proveedores': {
+      const lim = Math.min(parseInt(args.limite) || 50, 200);
+      const r = await db.query('SELECT id, nit, nombre, email, telefono, activo FROM proveedores ORDER BY nombre LIMIT $1', [lim]);
+      return r.rows;
+    }
+    case 'facturas_por_vencer': {
+      const dias = parseInt(args.dias) || 7;
+      const r = await db.query(`
+        SELECT f.id, f.numero_factura, f.valor_total, f.limite_pago, f.estado,
+               p.nombre AS proveedor
+        FROM facturas f
+        LEFT JOIN proveedores p ON p.id = f.proveedor_id
+        WHERE f.limite_pago IS NOT NULL
+          AND f.limite_pago <= CURRENT_DATE + INTERVAL '${dias} days'
+          AND f.estado NOT IN ('pagada','rechazada')
+        ORDER BY f.limite_pago ASC
+        LIMIT 20
+      `);
+      return r.rows;
+    }
+    case 'buscar_factura': {
+      const r = await db.query(`
+        SELECT f.*, p.nombre AS proveedor_nombre, p.nit AS proveedor_nit,
+               c.nombre AS categoria_nombre, a.nombre AS area_nombre
+        FROM facturas f
+        LEFT JOIN proveedores p ON p.id = f.proveedor_id
+        LEFT JOIN categorias_compra c ON c.id = f.categoria_id
+        LEFT JOIN areas a ON a.id = f.area_responsable_id
+        WHERE f.numero_factura ILIKE $1
+        LIMIT 10
+      `, ['%' + args.numero + '%']);
+      return r.rows;
+    }
+    case 'listar_categorias': {
+      const r = await db.query('SELECT id, nombre, color, activo FROM categorias_compra WHERE activo = TRUE ORDER BY nombre');
+      return r.rows;
+    }
+    case 'listar_areas': {
+      const r = await db.query('SELECT id, nombre, activo FROM areas WHERE activo = TRUE ORDER BY nombre');
+      return r.rows;
+    }
+    case 'estadisticas': {
+      const [total, proveedores, porEstado, valorTotal] = await Promise.all([
+        db.query('SELECT COUNT(*)::int AS c FROM facturas'),
+        db.query('SELECT COUNT(*)::int AS c FROM proveedores WHERE activo = TRUE'),
+        db.query('SELECT estado, COUNT(*)::int AS total FROM facturas GROUP BY estado'),
+        db.query("SELECT COALESCE(SUM(valor_total),0)::numeric AS v FROM facturas WHERE estado NOT IN ('rechazada')"),
+      ]);
+      return {
+        totalFacturas: total.rows[0].c,
+        proveedoresActivos: proveedores.rows[0].c,
+        valorTotal: parseFloat(valorTotal.rows[0].v),
+        porEstado: porEstado.rows
+      };
+    }
+    default: throw new Error('Tool no encontrada: ' + name);
+  }
+}
+
+const sessions = new Map();
+
+function rpcResult(id, result) { return { jsonrpc: '2.0', result, id }; }
+function rpcError(id, code, message) { return { jsonrpc: '2.0', error: { code, message }, id }; }
+
+function createRouter() {
+  const express = require('express');
+  const router = express.Router();
+  router.use(express.json());
+
+  router.get('/', (req, res) => res.json({ status: 'ok', server: 'docflow-mcp' }));
+
+  router.post('/', (req, res) => {
+    const msg = req.body;
+    if (!msg || msg.jsonrpc !== '2.0') {
+      return res.status(400).json(rpcError(null, -32600, 'Invalid Request'));
+    }
+    const sessionId = req.headers['mcp-session-id'];
+    const id = msg.id ?? null;
+
+    switch (msg.method) {
+      case 'initialize': {
+        const newSessionId = crypto.randomUUID();
+        sessions.set(newSessionId, { createdAt: Date.now() });
+        res.setHeader('mcp-session-id', newSessionId);
+        return res.json(rpcResult(id, {
+          protocolVersion: '2025-03-26',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'docflow-mcp', version: '1.0.0' }
+        }));
+      }
+      case 'tools/list': {
+        if (!sessionId || !sessions.has(sessionId)) {
+          return res.status(401).json(rpcError(id, -32001, 'Sesión inválida'));
+        }
+        return res.json(rpcResult(id, { tools: TOOLS }));
+      }
+      case 'tools/call': {
+        if (!sessionId || !sessions.has(sessionId)) {
+          return res.status(401).json(rpcError(id, -32001, 'Sesión inválida'));
+        }
+        const { name, arguments: args } = msg.params || {};
+        ejecutarTool(name, args || {}).then(result => {
+          res.json(rpcResult(id, { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] }));
+        }).catch(err => {
+          res.json(rpcResult(id, { isError: true, content: [{ type: 'text', text: 'Error: ' + err.message }] }));
+        });
+        return;
+      }
+      case 'notifications/initialized':
+        return res.status(202).end();
+      default:
+        return res.status(400).json(rpcError(id, -32601, 'Method not found'));
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createMiddleware: createRouter, ejecutarTool };

--- a/src/server.js
+++ b/src/server.js
@@ -33,6 +33,10 @@ app.use('/api/configuracion',  require('./routes/configuracion'));
 app.use('/api/audit',          require('./routes/audit'));
 app.use('/api/centros',        require('./routes/centros'));
 
+// ─── MCP ──────────────────────────────────────────────────────────────────────
+const mcp = require('./mcp');
+app.use('/mcp', mcp.createMiddleware());
+
 // ─── Health check ─────────────────────────────────────────────────────────────
 app.get('/api/health', (req, res) => {
   res.json({


### PR DESCRIPTION
Agrega endpoint MCP a DocFlow con:\n- JSON-RPC 2.0 con handshake initialize\n- 8 herramientas: listar_facturas, resumen_dashboard, listar_proveedores, facturas_por_vencer, buscar_factura, listar_categorias, listar_areas, estadisticas\n- Sesión mediante header mcp-session-id\n\nEl launcher gateway también se actualizó para manejar el handshake initialize automáticamente.